### PR TITLE
Patch for calling back results from Wine API in console.log

### DIFF
--- a/Assets/javascript/proj.js
+++ b/Assets/javascript/proj.js
@@ -129,14 +129,6 @@ var Chardonnay = ["beef", "chicken", "pork", "fish", "shrimp", "crab", "lobster"
 
 var wQueryURL = "https://cors-anywhere.herokuapp.com/https://api.globalwinescore.com/globalwinescores/latest/?wine=";
 
-$.ajax({
-  url: wQueryURL,
-  method: "GET",
-  headers: {'Authorization': 'Token 4d786bd8008d8fed360a5eb1a42ac9970ca664ba'}
-}).then(function(response) {
-  console.log(response);
-});
-
 // document.getElementsByClassName("wineButton").on("click", function (event) {
 $(document).on('click', ".wineButton", function () {
   event.preventDefault();
@@ -193,6 +185,13 @@ $(document).on('click', ".wineButton", function () {
       wQueryURL = "https://cors-anywhere.herokuapp.com/https://api.globalwinescore.com/globalwinescores/latest/?wine=Sauvignon_Blanc"
      
       console.log("Sauvignon Blanc");
+      $.ajax({
+      url: wQueryURL,
+      method: "GET",
+      headers: {'Authorization': 'Token 4d786bd8008d8fed360a5eb1a42ac9970ca664ba'}
+      }).then(function(response) {
+        console.log(response);
+      });
     } else {
       return;
     }


### PR DESCRIPTION
For some reason our one line code that pinar and I worked on didn't get pushed to the master. This bug fix will allow an API hit to return with results to the console.log when sauvignon Blanc returns as the favored choice.